### PR TITLE
Update twat.py

### DIFF
--- a/twat.py
+++ b/twat.py
@@ -17,6 +17,10 @@ possible_packages = [
     "apache2",
     "beef-xss",
 ];
+colour_headers = [
+    "\033[1;32;40m", #Bright Green   
+    "\033[1;31;40m", #Bright Red    
+];
 
 
 
@@ -30,4 +34,6 @@ def DependencyCheck(possible_packages):
         check = subprocess.Popen(["dpkg", "-s", x], stdout=devnull, stderr=subprocess.STDOUT);
         devnull.close();
         if check != 0:
-            print("Package - %s - is not installed." % x);
+            print("%sPackage - %s - is not installed." % (colour_headers[1], x));
+        else:
+            print("%sPackage - %s - is installed." % (colour_headers[0], x));


### PR DESCRIPTION
Added support for colour headers *(e.g. `\033[1;32;40m` for bright green)* and implemented on `success` and `fail` messages